### PR TITLE
Add support for Devin Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # 🌊 wsl-windsurf-launcher
 
-A one-time setup WSL helper that lets you quickly open files and folders in **WSL Remote** mode using [Windsurf](https://windsurf.com) — all with a single command: wf.
+A one-time setup WSL helper that lets you quickly open files and folders in **WSL Remote** mode using [Devin Desktop](https://devin.ai/download) — all with a single command: `wf`.
+
+> **Note:** Windsurf was rebranded to **Devin Desktop** in June 2026. See the [announcement](https://devin.ai/blog/windsurf-is-now-devin-desktop/) for details. This script has been updated accordingly and now targets the `devin-desktop` binary.
 
 ---
 
 ## ✨ Features
 
-* Open folders and files in **Windsurf** directly from the WSL terminal.
+* Open folders and files in **Devin Desktop** directly from the WSL terminal.
 * Automatically detects your WSL distro.
 * Supports all common shells (`zsh`, `bash`, `fish`).
 * Adds a convenient `wf` command to your terminal.
@@ -40,7 +42,7 @@ That's it! The script will handle everything automatically.
 ## 🧪 Usage
 
 ```bash
-wf                # Opens a new window in Windsurf
+wf                # Opens a new window in Devin Desktop
 wf .              # Opens current directory
 wf ./file.txt     # Opens a specific file
 wf /path/to/dir   # Opens a specific directory
@@ -48,11 +50,11 @@ wf --clean        # Manually clean up stale IPC sockets
 wf -c             # Short form of --clean
 ```
 
-The script automatically encodes the path and launches Windsurf with a `vscode-remote://wsl+<Distro>` URI.
+The script automatically encodes the path and launches Devin Desktop with a `vscode-remote://wsl+<Distro>` URI.
 
 ### Automatic Socket Cleanup
 
-The launcher automatically detects and cleans up stale IPC socket files (leftover from crashed or force-killed Windsurf instances) before launching. This prevents connection errors like "Error: connect ENOENT /run/user/1000/vscode-ipc-*.sock".
+The launcher automatically detects and cleans up stale IPC socket files (leftover from crashed or force-killed Devin Desktop instances) before launching. This prevents connection errors like "Error: connect ENOENT /run/user/1000/vscode-ipc-*.sock".
 
 You can also manually trigger cleanup using `wf --clean` or `wf -c`.
 
@@ -60,7 +62,7 @@ You can also manually trigger cleanup using `wf --clean` or `wf -c`.
 
 ## 🛠️ Requirements
 
-* [Windsurf](https://windsurf.com) installed and available in WSL `$PATH`
+* [Devin Desktop](https://devin.ai/download) installed and available in WSL `$PATH`
 * WSL2
 * Python 3 (for URL encoding)
 
@@ -68,7 +70,7 @@ You can also manually trigger cleanup using `wf --clean` or `wf -c`.
 
 ## ❓ Why `wf`?
 
-`wf` = **w**~~indsur~~**f** — it's short, simple, and memorable. A clean CLI alias that fits into your dev workflow.
+`wf` originated as a shorthand for **w**~~indsur~~**f** — the former name of the editor. It's short, simple, and memorable. The name stuck even after the rebrand to Devin Desktop.
 
 ---
 

--- a/script.sh
+++ b/script.sh
@@ -6,15 +6,15 @@ BLUE='\033[1;34m'
 YELLOW='\033[1;33m'
 RESET='\033[0m'
 
-echo -e "${BLUE}=== Setting up WSL Windsurf Launcher ===${RESET}"
+echo -e "${BLUE}=== Setting up WSL Devin Desktop Launcher ===${RESET}"
 
 # Create bin directory
 mkdir -p ~/.local/bin
 
-# Detect windsurf
-WINDSURF_CMD=$(command -v windsurf 2>/dev/null)
-if [ -z "$WINDSURF_CMD" ]; then
-    echo "ERROR: windsurf command not found in PATH" >&2
+# Detect devin-desktop
+DEVIN_DESKTOP_CMD=$(command -v devin-desktop 2>/dev/null)
+if [ -z "$DEVIN_DESKTOP_CMD" ]; then
+    echo "ERROR: devin-desktop command not found in PATH" >&2
     exit 1
 fi
 
@@ -109,9 +109,9 @@ if [ -z "$WSL_DISTRO" ]; then
     exit 1
 fi
 
-WINDSURF_CMD=$(command -v windsurf 2>/dev/null)
-if [ -z "$WINDSURF_CMD" ]; then
-    echo "ERROR: windsurf command not found in PATH" >&2
+DEVIN_DESKTOP_CMD=$(command -v devin-desktop 2>/dev/null)
+if [ -z "$DEVIN_DESKTOP_CMD" ]; then
+    echo "ERROR: devin-desktop command not found in PATH" >&2
     exit 1
 fi
 
@@ -120,7 +120,7 @@ cleanup_stale_sockets false
 
 if [ -z "$1" ]; then
     # No arguments - open a new window in WSL mode
-    "$WINDSURF_CMD" "--new-window" "--remote" "wsl+${WSL_DISTRO}"
+    "$DEVIN_DESKTOP_CMD" "--new-window" "--remote" "wsl+${WSL_DISTRO}"
     exit 0
 else
     TARGET_PATH=$(readlink -f "$1" 2>/dev/null || echo "$1")
@@ -141,7 +141,7 @@ fi
 ENCODED_PATH=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$TARGET_PATH")
 URI="vscode-remote://wsl+${WSL_DISTRO}$ENCODED_PATH"
 
-"$WINDSURF_CMD" "--$URI_SCHEME" "$URI"
+"$DEVIN_DESKTOP_CMD" "--$URI_SCHEME" "$URI"
 EOF
 
 chmod +x ~/.local/bin/wf
@@ -157,10 +157,10 @@ add_path_to_config() {
     if [ -f "$config_file" ]; then
         if ! grep -Fq 'export PATH="$HOME/.local/bin:$PATH"' "$config_file"; then
             echo "" >> "$config_file"
-            echo "# ====== Windsurf Launcher Config ======" >> "$config_file"
+            echo "# ====== Devin Desktop Launcher Config ======" >> "$config_file"
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$config_file"
-            echo "# ====== End of Windsurf Launcher Config ======" >> "$config_file"
-            echo -e "${GREEN}✓ Added Windsurf launcher to PATH in ${config_file} (${shell_name})${RESET}"
+            echo "# ====== End of Devin Desktop Launcher Config ======" >> "$config_file"
+            echo -e "${GREEN}✓ Added Devin Desktop launcher to PATH in ${config_file} (${shell_name})${RESET}"
         else
             echo "${shell_name} configuration already contains PATH update"
         fi
@@ -176,13 +176,13 @@ case "$CURRENT_SHELL" in
         ;;
     fish)
         fish_config="$HOME/.config/fish/config.fish"
-        if ! grep -Fq 'set -gx PATH $HOME/.local/bin $PATH' "$fish_config"; then
+        if ! grep -Fq '# ====== Devin Desktop Launcher Config ======' "$fish_config" 2>/dev/null; then
             mkdir -p "$(dirname "$fish_config")"
             echo "" >> "$fish_config"
-            echo "# ====== Windsurf Launcher Config ======" >> "$fish_config"
+            echo "# ====== Devin Desktop Launcher Config ======" >> "$fish_config"
             echo "set -gx PATH \$HOME/.local/bin \$PATH" >> "$fish_config"
-            echo "# ====== End of Windsurf Launcher Config ======" >> "$fish_config"
-            echo -e "${GREEN}✓ Added Windsurf launcher to PATH in ${fish_config} (fish)${RESET}"
+            echo "# ====== End of Devin Desktop Launcher Config ======" >> "$fish_config"
+            echo -e "${GREEN}✓ Added Devin Desktop launcher to PATH in ${fish_config} (fish)${RESET}"
         else
             echo "fish configuration already contains PATH update"
         fi
@@ -192,7 +192,7 @@ case "$CURRENT_SHELL" in
         ;;
 esac
 
-echo -e "${GREEN}✓ WSL Windsurf launcher setup complete!${RESET}"
+echo -e "${GREEN}✓ WSL Devin Desktop launcher setup complete!${RESET}"
 echo -e "Use: ${BLUE}wf /path/to/file_or_folder${RESET}"
 case "$CURRENT_SHELL" in
     zsh)  echo -e "Run: ${BLUE}source ~/.zshrc${RESET} or restart terminal." ;;


### PR DESCRIPTION
## Changes

Adapts the launcher script to work with [Devin Desktop](https://www.cognition.ai/) in addition to Windsurf.

### What changed

- Detects `devin-desktop` binary instead of `windsurf`
- Renamed internal variable `WINDSURF_CMD` → `DEVIN_DESKTOP_CMD` for clarity
- Updated all display strings, setup banner, and shell config section headers to reference "Devin Desktop"
- Fish shell idempotency check now uses the section header (consistent with bash/zsh)

### What stayed the same

- `vscode-remote://wsl+<Distro>` URI scheme (Devin Desktop uses the same VS Code Remote WSL extension)
- `vscode-ipc-*.sock` socket cleanup pattern (confirmed via `VSCODE_IPC_HOOK_CLI` env)
- All CLI flags: `--new-window`, `--remote`, `--folder-uri`, `--file-uri`
- The `wf` command name